### PR TITLE
Handle leading slash in assume role

### DIFF
--- a/main.go
+++ b/main.go
@@ -105,8 +105,14 @@ func collectFindings(secHubRegions []string) {
 		log.Fatalf("could not parse team map file: %v", err)
 	}
 
+	// Add a leading slash to the provided role if it doesn't already have one
+	formattedRole := options.AssumeRole
+	if !strings.HasPrefix(formattedRole, "/") {
+		formattedRole = "/" + formattedRole
+	}
+
 	for account, teamName := range accountsToTeams {
-		roleArn := fmt.Sprintf("arn:aws:iam::%v:role/%v", account.ID, options.AssumeRole)
+		roleArn := fmt.Sprintf("arn:aws:iam::%s:role%s", account.ID, formattedRole)
 
 		for _, secHubRegion := range secHubRegions {
 			log.Printf("getting findings for account %v in %v", account.ID, secHubRegion)


### PR DESCRIPTION
Consumers of the https://github.com/Enterprise-CMCS/security-hub-collector-ecs-runner module could pass an `AssumeRole` value with or without a leading slash. This fix handles both cases.

Manual testing: ran the Collector locally providing an `AssumeRole` value with and without a leading slash

